### PR TITLE
Make Gray Background on Map Window Larger

### DIFF
--- a/scss/app.scss
+++ b/scss/app.scss
@@ -134,7 +134,7 @@ button {
     height: 60px;
     width: 100%;
     cursor: ns-resize;
-    @include box-shadow(0px 0px 0px 1000px rgba($grayDarkest, 0.5));
+    @include box-shadow(0px 0px 0px 4000px rgba($grayDarkest, 0.5));
   }
 
   img {


### PR DESCRIPTION
On a 5K iMac display the box shadow used to indicate the active area is not large enough to cover the rest of the window. 2000px fixes it but 4000px leaves room for even larger or vertical screens.